### PR TITLE
Implement QFT decomposition pipeline

### DIFF
--- a/qft_native/__init__.py
+++ b/qft_native/__init__.py
@@ -1,0 +1,18 @@
+from .gates import Gate, RX, RY, RZ, CZ
+from .euler import hadamard_as_native
+from .cp_to_cz import cp_via_cz
+from .qft import qft
+from .simulator import to_qiskit, unitary
+
+__all__ = [
+    "Gate",
+    "RX",
+    "RY",
+    "RZ",
+    "CZ",
+    "hadamard_as_native",
+    "cp_via_cz",
+    "qft",
+    "to_qiskit",
+    "unitary",
+]

--- a/qft_native/cp_to_cz.py
+++ b/qft_native/cp_to_cz.py
@@ -1,0 +1,46 @@
+from qiskit import QuantumCircuit, transpile
+from .gates import RX, RY, RZ, CZ
+
+
+def cp_via_cz(ctrl, tgt, theta):
+    """Return native gate list for controlled-phase e^{i theta |11><11|}."""
+    n = max(ctrl, tgt) + 1
+    qc = QuantumCircuit(n)
+    qc.cp(theta, ctrl, tgt)
+    tc = transpile(qc, basis_gates=["rx", "ry", "rz", "cz"], optimization_level=0)
+
+    gates = []
+    for inst in tc.data:
+        name = inst.operation.name
+        qargs = [tc.find_bit(q).index for q in inst.qubits]
+        params = inst.operation.params
+        if name == "rx":
+            gates.append(RX(qargs[0], params[0]))
+        elif name == "ry":
+            gates.append(RY(qargs[0], params[0]))
+        elif name == "rz":
+            gates.append(RZ(qargs[0], params[0]))
+        elif name == "cz":
+            gates.append(CZ(*qargs))
+    return gates
+
+def swap_via_cz(a, b):
+    """Return native gate list implementing a SWAP between qubits ``a`` and ``b`` using CZs."""
+    n = max(a, b) + 1
+    qc = QuantumCircuit(n)
+    qc.swap(a, b)
+    tc = transpile(qc, basis_gates=["rx", "ry", "rz", "cz"], optimization_level=0)
+    gates = []
+    for inst in tc.data:
+        name = inst.operation.name
+        qargs = [tc.find_bit(q).index for q in inst.qubits]
+        params = inst.operation.params
+        if name == "rx":
+            gates.append(RX(qargs[0], params[0]))
+        elif name == "ry":
+            gates.append(RY(qargs[0], params[0]))
+        elif name == "rz":
+            gates.append(RZ(qargs[0], params[0]))
+        elif name == "cz":
+            gates.append(CZ(*qargs))
+    return gates

--- a/qft_native/euler.py
+++ b/qft_native/euler.py
@@ -1,0 +1,11 @@
+import math
+from .gates import RX, RZ
+
+
+def hadamard_as_native(q):
+    """Decompose a Hadamard gate into native rotations."""
+    return [
+        RZ(q, math.pi / 2),
+        RX(q, math.pi / 2),
+        RZ(q, math.pi / 2),
+    ]

--- a/qft_native/gates.py
+++ b/qft_native/gates.py
@@ -1,48 +1,24 @@
-# qft_native/gates.py
 from dataclasses import dataclass
+
 @dataclass(frozen=True)
 class Gate:
-    name: str; qubits: tuple; params: tuple = ()
-class RX(Gate):  def __init__(self,q,θ): super().__init__("RX",(q,), (θ,))
-class RY(Gate):  def __init__(self,q,θ): super().__init__("RY",(q,), (θ,))
-class RZ(Gate):  def __init__(self,q,θ): super().__init__("RZ",(q,), (θ,))
-class CZ(Gate):  def __init__(self,ctrl,tgt): super().__init__("CZ",(ctrl,tgt))
+    """Representation of a native gate."""
+    name: str
+    qubits: tuple
+    params: tuple = ()
 
-# qft_native/euler.py
-import math
-def hadamard_as_native(q):
-    return [RY(q, math.pi/2), RZ(q, math.pi), RY(q, math.pi/2)]
+class RX(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RX", (q,), (theta,))
 
-# qft_native/cp_to_cz.py
-def cp_via_cz(ctrl, tgt, theta):
-    """Return native gate list for controlled-phase e^{i θ |11⟩⟨11|}."""
-    from .gates import CZ, RZ
-    return [
-        CZ(ctrl, tgt),
-        RZ(tgt, -theta/2),
-        CZ(ctrl, tgt),
-        RZ(tgt,  theta/2),
-    ]
+class RY(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RY", (q,), (theta,))
 
-# qft_native/qft.py
-from math import pi
-from .gates import *
-from .euler import hadamard_as_native
-from .cp_to_cz import cp_via_cz
-def qft(n, *, do_swaps=True, adjoint=False, atol=1e-10):
-    g=[]
-    angles=[pi/2**k for k in range(1,n)]          # base angles
-    qubits=range(n) if not adjoint else range(n-1,-1,-1)
-    sign = -1 if adjoint else 1
-    for j,qj in enumerate(qubits):
-        g+=hadamard_as_native(qj)
-        for k,θ in enumerate(angles[:n-j-1], start=1):
-            ctrl = qj+k if not adjoint else qj-k
-            g+=cp_via_cz(ctrl, qj, sign*θ)
-    if do_swaps and not adjoint:
-        for i in range(n//2):
-            ctrl, tgt = i, n-1-i
-            g+=cp_via_cz(ctrl,tgt,pi)            # H-CNOT-H swap via CZ (3×CZ)
-            g+=cp_via_cz(tgt,ctrl,pi)
-            g+=cp_via_cz(ctrl,tgt,pi)
-    return g
+class RZ(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RZ", (q,), (theta,))
+
+class CZ(Gate):
+    def __init__(self, ctrl, tgt):
+        super().__init__("CZ", (ctrl, tgt))

--- a/qft_native/qft.py
+++ b/qft_native/qft.py
@@ -1,0 +1,34 @@
+from math import pi
+from .euler import hadamard_as_native
+from .cp_to_cz import cp_via_cz, swap_via_cz
+
+
+def qft(n, *, do_swaps=True, adjoint=False):
+    """Return a list of native gates implementing the QFT on ``n`` qubits."""
+    gates = []
+    if adjoint:
+        qubits = range(n)
+        for j in qubits:
+            # inverse order of forward circuit
+            for k in range(j):
+                angle = -pi / (2 ** (j - k))
+                gates += cp_via_cz(j, k, angle)
+            gates += hadamard_as_native(j)
+        if do_swaps:
+            for i in range(n // 2):
+                ctrl, tgt = i, n - 1 - i
+                gates += swap_via_cz(ctrl, tgt)
+        return gates
+
+    # forward QFT
+    for j in reversed(range(n)):
+        for k in reversed(range(j)):
+            angle = pi * (2 ** (k - j))
+            gates += cp_via_cz(k, j, angle)
+        gates += hadamard_as_native(j)
+
+    if do_swaps:
+        for i in range(n // 2):
+            ctrl, tgt = i, n - 1 - i
+            gates += swap_via_cz(ctrl, tgt)
+    return gates

--- a/qft_native/reverse.py
+++ b/qft_native/reverse.py
@@ -1,0 +1,17 @@
+from typing import Iterable
+from .gates import Gate
+
+
+def reverse_circuit(gates: Iterable[Gate]):
+    """Return the reversed list of gates with each gate adjointed."""
+    rev = []
+    for g in reversed(list(gates)):
+        if g.name in {"RX", "RY", "RZ"}:
+            theta = -g.params[0]
+            cls = type(g)
+            rev.append(cls(g.qubits[0], theta))
+        elif g.name == "CZ":
+            rev.append(g)  # self-adjoint
+        else:
+            raise ValueError(f"Unsupported gate: {g}")
+    return rev

--- a/qft_native/simulator.py
+++ b/qft_native/simulator.py
@@ -1,0 +1,26 @@
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Operator
+from .gates import RX, RY, RZ, CZ
+
+
+def to_qiskit(gates, n):
+    """Convert a list of native gates into a Qiskit ``QuantumCircuit``."""
+    qc = QuantumCircuit(n)
+    for g in gates:
+        if isinstance(g, RX):
+            qc.rx(g.params[0], g.qubits[0])
+        elif isinstance(g, RY):
+            qc.ry(g.params[0], g.qubits[0])
+        elif isinstance(g, RZ):
+            qc.rz(g.params[0], g.qubits[0])
+        elif isinstance(g, CZ):
+            qc.cz(*g.qubits)
+        else:
+            raise ValueError(f"Unsupported gate type: {g}")
+    return qc
+
+
+def unitary(gates, n):
+    """Return the unitary matrix for the given native gate sequence."""
+    qc = to_qiskit(gates, n)
+    return Operator(qc).data

--- a/qft_native/tests/test_qft.py
+++ b/qft_native/tests/test_qft.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from qiskit.quantum_info import Operator
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from qft_native import qft, to_qiskit
+
+
+def test_qft_produces_circuit():
+    n = 3
+    gates = qft(n)
+    circuit = to_qiskit(gates, n)
+    assert circuit.num_qubits == n
+    assert len(gates) > 0
+    # ensure resulting unitary is unitary by verifying Operator can be built
+    Operator(circuit)


### PR DESCRIPTION
## Summary
- implement native gate classes and basic Hadamard decomposition
- implement controlled-phase and swap decompositions via CZ using Qiskit's transpiler
- add QFT routine capable of arbitrary number of qubits
- provide simple simulator utilities
- add minimal test ensuring a circuit is generated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2b04cdac8331b795f635a700d1c8