### PR TITLE
Fix flake8 issues in gate helpers and tests

### DIFF
--- a/qft_native/cp_to_cz.py
+++ b/qft_native/cp_to_cz.py
@@ -7,7 +7,11 @@ def cp_via_cz(ctrl, tgt, theta):
     n = max(ctrl, tgt) + 1
     qc = QuantumCircuit(n)
     qc.cp(theta, ctrl, tgt)
-    tc = transpile(qc, basis_gates=["rx", "ry", "rz", "cz"], optimization_level=0)
+    tc = transpile(
+        qc,
+        basis_gates=["rx", "ry", "rz", "cz"],
+        optimization_level=0,
+    )
 
     gates = []
     for inst in tc.data:
@@ -24,12 +28,18 @@ def cp_via_cz(ctrl, tgt, theta):
             gates.append(CZ(*qargs))
     return gates
 
+
 def swap_via_cz(a, b):
-    """Return native gate list implementing a SWAP between qubits ``a`` and ``b`` using CZs."""
+    """Return native gate list implementing a SWAP between qubits ``a`` and
+    ``b`` using CZs."""
     n = max(a, b) + 1
     qc = QuantumCircuit(n)
     qc.swap(a, b)
-    tc = transpile(qc, basis_gates=["rx", "ry", "rz", "cz"], optimization_level=0)
+    tc = transpile(
+        qc,
+        basis_gates=["rx", "ry", "rz", "cz"],
+        optimization_level=0,
+    )
     gates = []
     for inst in tc.data:
         name = inst.operation.name

--- a/qft_native/gates.py
+++ b/qft_native/gates.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class Gate:
     """Representation of a native gate."""
@@ -7,17 +8,21 @@ class Gate:
     qubits: tuple
     params: tuple = ()
 
+
 class RX(Gate):
     def __init__(self, q, theta):
         super().__init__("RX", (q,), (theta,))
+
 
 class RY(Gate):
     def __init__(self, q, theta):
         super().__init__("RY", (q,), (theta,))
 
+
 class RZ(Gate):
     def __init__(self, q, theta):
         super().__init__("RZ", (q,), (theta,))
+
 
 class CZ(Gate):
     def __init__(self, ctrl, tgt):

--- a/qft_native/tests/test_qft.py
+++ b/qft_native/tests/test_qft.py
@@ -2,19 +2,26 @@ import os
 import sys
 from qiskit.quantum_info import Operator
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    ),
+)  # noqa: E402
 
-from qft_native import qft, to_qiskit
+from qft_native import qft, to_qiskit  # noqa: E402
 
 
 def test_qft_produces_circuit(n):
-    
+
     gates = qft(n)
     circuit = to_qiskit(gates, n)
     assert circuit.num_qubits == n
     assert len(gates) > 0
     # ensure resulting unitary is unitary by verifying Operator can be built
     Operator(circuit)
-    print(circuit.draw()) # This will display the circuit if run in an interactive environment
+    # This will display the circuit if run in an interactive environment
+    print(circuit.draw())
+
 
 test_qft_produces_circuit(4)


### PR DESCRIPTION
## Summary
- fix spacing between definitions in `gates.py`
- ensure blank lines before `swap_via_cz` and wrap long lines in `cp_to_cz.py`
- reformat `test_qft.py` for shorter lines and newline handling

## Testing
- `flake8 qft_native/cp_to_cz.py qft_native/gates.py qft_native/tests/test_qft.py`
- `pytest -q` *(fails: fixture 'n' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f39e9397c83319b217624a319fce6