### PR TITLE
Update gitignore for pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 venv/
+.pytest_cache/
 


### PR DESCRIPTION
## Summary
- add `.pytest_cache/` exclusion to `.gitignore`

## Testing
- `pytest -q` *(fails: fixture 'n' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f39e30ea08331b27bedfcd6c347ba