### PR TITLE
Fix tests package import

### DIFF
--- a/qft_native/tests/test_qft.py
+++ b/qft_native/tests/test_qft.py
@@ -1,10 +1,6 @@
-import os
-import sys
 from qiskit.quantum_info import Operator
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
-from qft_native import qft, to_qiskit
+from .. import qft, to_qiskit
 
 
 def test_qft_produces_circuit(n):


### PR DESCRIPTION
## Summary
- add a package initializer in `qft_native/tests`
- use relative imports in the tests so `sys.path` is untouched

## Testing
- `pytest -q` *(fails: fixture 'n' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f39d729b8833188a2a39bbc3b8cef