### PR TITLE
Add QPE decomposition package

### DIFF
--- a/nQubitQFT_decompose/test_qft.py
+++ b/nQubitQFT_decompose/test_qft.py
@@ -1,9 +1,16 @@
 from qiskit.quantum_info import Operator
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(__file__)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from qft_native.qft import qft
 from qft_native.simulator import to_qiskit
 
 
-def test_qft_produces_circuit(n):
+def test_qft_produces_circuit(n: int = 3):
     """Basic check that ``qft`` returns a valid circuit."""
     gates = qft(n)
     circuit = to_qiskit(gates, n)
@@ -14,4 +21,4 @@ def test_qft_produces_circuit(n):
 
 
 if __name__ == "__main__":
-    test_qft_produces_circuit(3)
+    test_qft_produces_circuit()

--- a/nQubitQPE_decompose/benchmark_qpe.py
+++ b/nQubitQPE_decompose/benchmark_qpe.py
@@ -1,0 +1,60 @@
+import argparse
+import time
+
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import QFT
+
+import os
+import sys
+
+# Ensure the "qpe_native" package inside ``nQubitQPE_decompose`` is importable
+PROJECT_ROOT = os.path.dirname(__file__)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from qpe_native.qpe import qpe
+from qpe_native.simulator import to_qiskit
+
+
+def build_native_circuit(num_ancilla: int, theta: float) -> QuantumCircuit:
+    """Return the native QPE circuit."""
+    gates = qpe(num_ancilla, theta)
+    return to_qiskit(gates, num_ancilla + 1)
+
+
+def build_standard_circuit(num_ancilla: int, theta: float) -> QuantumCircuit:
+    """Return a standard QPE circuit transpiled to native basis gates."""
+    qc = QuantumCircuit(num_ancilla + 1)
+    for j in range(num_ancilla):
+        qc.h(j)
+    for j in range(num_ancilla):
+        qc.cp(theta * (2 ** j), j, num_ancilla)
+    qft = QFT(num_ancilla, do_swaps=False, inverse=True)
+    qc.append(qft.to_instruction(), range(num_ancilla))
+    return transpile(qc, basis_gates=["rx", "ry", "rz", "cz"])
+
+
+def benchmark(num_ancilla: int, theta: float) -> None:
+    start = time.perf_counter()
+    native_circuit = build_native_circuit(num_ancilla, theta)
+    native_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    transpiled = build_standard_circuit(num_ancilla, theta)
+    transpile_time = time.perf_counter() - start
+
+    native_counts = native_circuit.count_ops()
+    transpiled_counts = transpiled.count_ops()
+
+    print(f"Native circuit gate counts: {native_counts}")
+    print(f"Standard circuit gate counts: {transpiled_counts}")
+    print(f"Native circuit build time: {native_time:.6f} s")
+    print(f"Standard transpile time: {transpile_time:.6f} s")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark native vs standard QPE")
+    parser.add_argument("n", type=int, nargs="?", default=3, help="Number of ancilla qubits")
+    parser.add_argument("theta", type=float, nargs="?", default=3.14159 / 2, help="Phase angle")
+    args = parser.parse_args()
+    benchmark(args.n, args.theta)

--- a/nQubitQPE_decompose/qpe_native/__init__.py
+++ b/nQubitQPE_decompose/qpe_native/__init__.py
@@ -1,0 +1,20 @@
+from .gates import Gate, RX, RY, RZ, CZ
+from .euler import hadamard_as_native
+from .cp_to_cz import cp_via_cz
+from .qpe import qpe
+from .qft import qft
+from .simulator import to_qiskit, unitary
+
+__all__ = [
+    "Gate",
+    "RX",
+    "RY",
+    "RZ",
+    "CZ",
+    "hadamard_as_native",
+    "cp_via_cz",
+    "qpe",
+    "qft",
+    "to_qiskit",
+    "unitary",
+]

--- a/nQubitQPE_decompose/qpe_native/cp_to_cz.py
+++ b/nQubitQPE_decompose/qpe_native/cp_to_cz.py
@@ -1,0 +1,37 @@
+"""Utility decompositions for CP and SWAP using only native gates."""
+
+from math import pi
+
+from .gates import RX, RY, RZ, CZ
+
+
+def _cnot_via_cz(ctrl: int, tgt: int):
+    """Return gate list for a CX using CZ and single-qubit rotations."""
+    return [
+        RY(tgt, pi / 2),
+        RX(tgt, pi),
+        CZ(ctrl, tgt),
+        RY(tgt, pi / 2),
+        RX(tgt, pi),
+    ]
+
+
+def cp_via_cz(ctrl: int, tgt: int, theta: float):
+    """Return gate list implementing ``CP(theta)`` using CZ gates."""
+
+    gates = [RZ(ctrl, theta / 2)]
+    gates += _cnot_via_cz(ctrl, tgt)
+    gates.append(RZ(tgt, -theta / 2))
+    gates += _cnot_via_cz(ctrl, tgt)
+    gates.append(RZ(tgt, theta / 2))
+    return gates
+
+
+def swap_via_cz(a: int, b: int):
+    """Return gate list implementing ``SWAP(a, b)`` using CZ gates."""
+
+    gates = []
+    gates += _cnot_via_cz(a, b)
+    gates += _cnot_via_cz(b, a)
+    gates += _cnot_via_cz(a, b)
+    return gates

--- a/nQubitQPE_decompose/qpe_native/euler.py
+++ b/nQubitQPE_decompose/qpe_native/euler.py
@@ -1,0 +1,11 @@
+import math
+from .gates import RX, RZ
+
+
+def hadamard_as_native(q):
+    """Decompose a Hadamard gate into native rotations."""
+    return [
+        RZ(q, math.pi / 2),
+        RX(q, math.pi / 2),
+        RZ(q, math.pi / 2),
+    ]

--- a/nQubitQPE_decompose/qpe_native/gates.py
+++ b/nQubitQPE_decompose/qpe_native/gates.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Gate:
+    """Representation of a native gate."""
+    name: str
+    qubits: tuple
+    params: tuple = ()
+
+
+class RX(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RX", (q,), (theta,))
+
+
+class RY(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RY", (q,), (theta,))
+
+
+class RZ(Gate):
+    def __init__(self, q, theta):
+        super().__init__("RZ", (q,), (theta,))
+
+
+class CZ(Gate):
+    def __init__(self, ctrl, tgt):
+        super().__init__("CZ", (ctrl, tgt))

--- a/nQubitQPE_decompose/qpe_native/qft.py
+++ b/nQubitQPE_decompose/qpe_native/qft.py
@@ -1,0 +1,34 @@
+from math import pi
+from .euler import hadamard_as_native
+from .cp_to_cz import cp_via_cz, swap_via_cz
+
+
+def qft(n, *, do_swaps=True, adjoint=False):
+    """Return a list of native gates implementing the QFT on ``n`` qubits."""
+    gates = []
+    if adjoint:
+        qubits = range(n)
+        for j in qubits:
+            # inverse order of forward circuit
+            for k in range(j):
+                angle = -pi / (2 ** (j - k))
+                gates += cp_via_cz(j, k, angle)
+            gates += hadamard_as_native(j)
+        if do_swaps:
+            for i in range(n // 2):
+                ctrl, tgt = i, n - 1 - i
+                gates += swap_via_cz(ctrl, tgt)
+        return gates
+
+    # forward QFT
+    for j in reversed(range(n)):
+        for k in reversed(range(j)):
+            angle = pi * (2 ** (k - j))
+            gates += cp_via_cz(k, j, angle)
+        gates += hadamard_as_native(j)
+
+    if do_swaps:
+        for i in range(n // 2):
+            ctrl, tgt = i, n - 1 - i
+            gates += swap_via_cz(ctrl, tgt)
+    return gates

--- a/nQubitQPE_decompose/qpe_native/qpe.py
+++ b/nQubitQPE_decompose/qpe_native/qpe.py
@@ -1,0 +1,29 @@
+from math import pi
+
+from .euler import hadamard_as_native
+from .cp_to_cz import cp_via_cz
+from .qft import qft
+
+
+def qpe(num_ancilla: int, theta: float):
+    """Return a list of native gates implementing QPE for RZ(theta).
+
+    The algorithm estimates the phase of ``RZ(theta)`` given the eigenstate
+    ``|1>`` on the target qubit. ``num_ancilla`` specifies the number of
+    ancilla qubits used for phase estimation.
+    """
+    gates = []
+    # Apply Hadamard to ancilla qubits
+    for j in range(num_ancilla):
+        gates += hadamard_as_native(j)
+
+    target = num_ancilla
+
+    # Apply controlled RZ^{2^k}
+    for k in range(num_ancilla):
+        angle = theta * (2 ** k)
+        gates += cp_via_cz(k, target, angle)
+
+    # Inverse QFT on ancilla qubits without swaps
+    gates += qft(num_ancilla, do_swaps=False, adjoint=True)
+    return gates

--- a/nQubitQPE_decompose/qpe_native/reverse.py
+++ b/nQubitQPE_decompose/qpe_native/reverse.py
@@ -1,0 +1,17 @@
+from typing import Iterable
+from .gates import Gate
+
+
+def reverse_circuit(gates: Iterable[Gate]):
+    """Return the reversed list of gates with each gate adjointed."""
+    rev = []
+    for g in reversed(list(gates)):
+        if g.name in {"RX", "RY", "RZ"}:
+            theta = -g.params[0]
+            cls = type(g)
+            rev.append(cls(g.qubits[0], theta))
+        elif g.name == "CZ":
+            rev.append(g)  # self-adjoint
+        else:
+            raise ValueError(f"Unsupported gate: {g}")
+    return rev

--- a/nQubitQPE_decompose/qpe_native/simulator.py
+++ b/nQubitQPE_decompose/qpe_native/simulator.py
@@ -1,0 +1,26 @@
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Operator
+from .gates import RX, RY, RZ, CZ
+
+
+def to_qiskit(gates, n):
+    """Convert a list of native gates into a Qiskit ``QuantumCircuit``."""
+    qc = QuantumCircuit(n)
+    for g in gates:
+        if isinstance(g, RX):
+            qc.rx(g.params[0], g.qubits[0])
+        elif isinstance(g, RY):
+            qc.ry(g.params[0], g.qubits[0])
+        elif isinstance(g, RZ):
+            qc.rz(g.params[0], g.qubits[0])
+        elif isinstance(g, CZ):
+            qc.cz(*g.qubits)
+        else:
+            raise ValueError(f"Unsupported gate type: {g}")
+    return qc
+
+
+def unitary(gates, n):
+    """Return the unitary matrix for the given native gate sequence."""
+    qc = to_qiskit(gates, n)
+    return Operator(qc).data

--- a/nQubitQPE_decompose/test_qpe.py
+++ b/nQubitQPE_decompose/test_qpe.py
@@ -1,0 +1,26 @@
+from qiskit.quantum_info import Operator
+from math import pi
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(__file__)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from qpe_native.qpe import qpe
+from qpe_native.simulator import to_qiskit
+
+
+def test_qpe_produces_circuit(n: int = 3):
+    """Basic check that ``qpe`` returns a valid circuit."""
+    theta = pi / 2
+    gates = qpe(n, theta)
+    circuit = to_qiskit(gates, n + 1)
+    assert circuit.num_qubits == n + 1
+    assert len(gates) > 0
+    Operator(circuit)  # ensure circuit is unitary
+    print(circuit.draw())
+
+
+if __name__ == "__main__":
+    test_qpe_produces_circuit()


### PR DESCRIPTION
## Summary
- add a new `nQubitQPE_decompose` package implementing a simple Quantum Phase Estimation circuit
- provide a benchmark script for the QPE decomposition
- export `qpe` and `qft` from the new native module
- include tests for the QPE circuit
- update existing QFT test to run without fixtures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6bde693c83318c004af2e630116c